### PR TITLE
Frequency Estimation Accounting for Sweep Rate

### DIFF
--- a/bladesight/btt/infer/cff.py
+++ b/bladesight/btt/infer/cff.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 from typing import List, Dict, Union
+from tqdm.auto import tqdm
 
 def cff_method_single_revolution(
     df_blade : pd.DataFrame,
@@ -172,7 +173,8 @@ def perform_CFF_fit(
     EO_solutions = []
     EO_errors = {}
     df_resonance_window = df_blade.query(f"n >= {n_start} and n <= {n_end}")
-    for EO in EOs:
+    # for EO in EOs:
+    for EO in tqdm(EOs, desc="Processing EOs"):
         df_cff_params = cff_method_multiple_revolutions(
             df_resonance_window,
             theta_sensor_set,

--- a/bladesight/btt/infer/sdof.py
+++ b/bladesight/btt/infer/sdof.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 from scipy.optimize import differential_evolution
 
@@ -194,27 +194,58 @@ def perform_SDoF_fit(
     df_blade : pd.DataFrame,
     n_start : int,
     n_end : int,
-    EOs : List[int] = np.arange(1, 20),
-    delta_st_max : int = 10,
+    EOs : Optional[List[int]] = np.arange(1, 20),
+    omega_n_bounds : Optional[List[float]] = [None, None],
+    zeta_bounds : Optional[List[float]] = [0.0001, 0.3],
+    delta_st_bounds : Optional[List[float]] = [0, 10],
+    phi_0_bounds : Optional[List[float]] = [0, 2*np.pi],
+    signal_suffix : Optional[str] = "_filt" ,
+    amplitude_scaling_factor : float = 1,
+    differential_evolution_optimiser_kwargs: Optional[dict] = {'seed': 42},
     verbose : bool = False
 ) -> Dict[str, float]:
-    """This function receives a blade tip deflection DataFrame, and returns 
-    the SDoF fit model parameters after fitting.
+    """
+    Fit an SDoF model to blade tip deflection data over a specified revolution range.
 
-    Args:
-        df_blade (pd.DataFrame): The blade tip deflection DataFrame.
-        n_start (int): The starting revolution number of the resonance 
-            you want to fit.
-        n_end (int): The ending revolution number of the resonance 
-            you want to fit.
-        EOs (List[int], optional): The list of EOs to search for. Defaults 
-            to np.arange(1, 20).
-        delta_st_max (int, optional): The maximum static deflection within our optimization 
-            bounds. Defaults to 10.
-        verbose (bool, optional): Whether to print the progress. Defaults to False.
-
+    Parameters
+    ----------
+    df_blade : pd.DataFrame
+        The blade tip deflection DataFrame.
+    n_start : int
+        The starting revolution number of the resonance to be used in the fit.
+    n_end : int
+        The ending revolution number of the resonance to be used in the fit.
+    EOs : List[int], optional
+        Range of engine orders to consider, defaults to np.arange(1, 20).
+    omega_n_bounds : List[float], optional
+        [min, max] bounds for resonant speed Ωₙ (radians/second). If None, set per EO as
+        (min(df_blade['Omega'])*EO, max(df_blade['Omega'])*EO).
+    zeta_bounds : list of float, optional
+        [min, max] bounds for damping ratio ζ, default to: [0.0001, 0.3].
+    delta_st_bounds : list of float, optional
+        [min, max] bounds for static deflection δₛₜ, , defaults to [0, 10].
+    phi_0_bounds : list of float, optional
+        [min, max] bounds for phase offset φ₀ in radians, defaults to [0, 2π].
+    signal_suffix : str, optional
+        Suffix appended to deflection column names, defaults to "_filt".
+    amplitude_scaling_factor : float, optional
+        Scaling factor for amplitude weighting, defaults to 1.
+    differential_evolution_optimiser_kwargs : dict, optional
+        Additional arguments for the differential evolution optimizer, defaults to {'seed': 42}.
+        If you want to use the default settings, pass an empty dictionary.
+    verbose : bool, optional
+        If True, print progress updates, defaults to False.
     Returns:
         Dict[str, float]: The fitted model parameters.
+    Returns
+    -------
+    Dict[str, Union[float, int]]
+        Fitted parameters, including:
+        - "omega_n": Natural frequency (in Hz).
+        - "zeta": Damping ratio.
+        - "delta_st": Static deflection.
+        - "phi_0": Phase offset in radians.
+        - "EO": Engine order with minimum error.
     """
     df_resonance_window = df_blade.query(f"n >= {n_start} and n <= {n_end}")
     measured_tip_deflection_signals = [
@@ -223,27 +254,28 @@ def perform_SDoF_fit(
         if col.endswith("_filt")
     ]
     PROBE_COUNT = len(measured_tip_deflection_signals)
-    eo_solutions = []
+    EO_solutions = []
     for EO in EOs:
         if verbose:
             print("NOW SOLVING FOR EO = ", EO, " of ", EOs)
-        omega_n_min = df_resonance_window["Omega"].min() * EO
-        omega_n_max = df_resonance_window["Omega"].max() * EO
-        ln_zeta_min = np.log(0.0001)
-        ln_zeta_max = np.log(0.3)
-        delta_st_min = 0
-        phi_0_min = 0
-        phi_0_max = 2*np.pi
+        
+        if omega_n_bounds.__contains__(None):
+            omega_n_bounds[0] = df_resonance_window["Omega"].min() * EO
+            omega_n_bounds[1] = df_resonance_window["Omega"].max() * EO
+        if omega_n_bounds.__contains__(None) == False:
+            omega_n_bounds[0] = omega_n_bounds[0]
+            omega_n_bounds[1] = omega_n_bounds[1]
+
         bounds = [
-            (omega_n_min, omega_n_max),
-            (ln_zeta_min, ln_zeta_max),
-            (delta_st_min, delta_st_max),
-            (phi_0_min, phi_0_max),
+            (omega_n_bounds[0], omega_n_bounds[1]),
+            (zeta_bounds[0], zeta_bounds[1]),
+            (delta_st_bounds[0], delta_st_bounds[1]),
+            (phi_0_bounds[0], phi_0_bounds[1]),
         ]
         tip_deflections_set = []
         theta_sensor_set = []
         for i_probe in range(PROBE_COUNT):
-            z_max = df_resonance_window[f"x_p{i_probe+1}_filt"].abs().max()
+            z_max = df_resonance_window[f"x_p{i_probe+1}"+signal_suffix].abs().max()
             z_min = -z_max
             bounds.extend(
                 [
@@ -252,7 +284,7 @@ def perform_SDoF_fit(
                 ]
             )
             tip_deflections_set.append(
-                df_resonance_window[f"x_p{i_probe+1}_filt"].values
+                df_resonance_window[f"x_p{i_probe+1}"+signal_suffix].values
             )
             theta_sensor_set.append(
                 df_resonance_window[f"AoA_p{i_probe+1}"].median()
@@ -265,14 +297,16 @@ def perform_SDoF_fit(
                 df_resonance_window['Omega'].values,
                 EO,
                 theta_sensor_set,
-                2
+                amplitude_scaling_factor,
             ),
-            seed=42
+            **differential_evolution_optimiser_kwargs
         )
-        eo_solutions.append(multiple_probes_solution)
-    best_EO_arg = np.argmin([solution.fun for solution in eo_solutions])
+        EO_solutions.append(multiple_probes_solution)
+    
+    # Select the best EO
+    best_EO_arg = np.argmin([solution.fun for solution in EO_solutions])
     best_EO = EOs[best_EO_arg]
-    best_solution = eo_solutions[best_EO_arg]
+    best_solution = EO_solutions[best_EO_arg]
     return {
         "omega_n" : best_solution.x[0] / (2*np.pi),
         "zeta" : np.exp(best_solution.x[1]),

--- a/bladesight/btt/infer/sdof.py
+++ b/bladesight/btt/infer/sdof.py
@@ -252,7 +252,8 @@ def perform_SDoF_fit(
     measured_tip_deflection_signals = [
         col 
         for col in df_resonance_window
-        if col.endswith("_filt")
+        # if col.endswith("_filt")
+        if col.startswith("x_p") and col.endswith(signal_suffix)
     ]
     PROBE_COUNT = len(measured_tip_deflection_signals)
     EO_solutions = []
@@ -264,9 +265,9 @@ def perform_SDoF_fit(
         if omega_n_bounds.__contains__(None):
             omega_n_bounds[0] = df_resonance_window["Omega"].min() * EO
             omega_n_bounds[1] = df_resonance_window["Omega"].max() * EO
-        if omega_n_bounds.__contains__(None) == False:
-            omega_n_bounds[0] = omega_n_bounds[0]
-            omega_n_bounds[1] = omega_n_bounds[1]
+        # if omega_n_bounds.__contains__(None) == False:
+        #     omega_n_bounds[0] = omega_n_bounds[0]
+        #     omega_n_bounds[1] = omega_n_bounds[1]
 
         bounds = [
             (omega_n_bounds[0], omega_n_bounds[1]),

--- a/bladesight/btt/infer/sdof.py
+++ b/bladesight/btt/infer/sdof.py
@@ -196,7 +196,7 @@ def perform_SDoF_fit(
     n_end : int,
     EOs : Optional[List[int]] = np.arange(1, 20),
     omega_n_bounds : Optional[List[float]] = [None, None],
-    zeta_bounds : Optional[List[float]] = [0.0001, 0.3],
+    ln_zeta_bounds : Optional[List[float]] = [np.log(0.0001), np.log(0.3)],
     delta_st_bounds : Optional[List[float]] = [0, 10],
     phi_0_bounds : Optional[List[float]] = [0, 2*np.pi],
     signal_suffix : Optional[str] = "_filt" ,
@@ -271,7 +271,7 @@ def perform_SDoF_fit(
 
         bounds = [
             (omega_n_bounds[0], omega_n_bounds[1]),
-            (zeta_bounds[0], zeta_bounds[1]),
+            (ln_zeta_bounds[0], ln_zeta_bounds[1]),
             (delta_st_bounds[0], delta_st_bounds[1]),
             (phi_0_bounds[0], phi_0_bounds[1]),
         ]

--- a/bladesight/btt/infer/sdof.py
+++ b/bladesight/btt/infer/sdof.py
@@ -245,7 +245,8 @@ def perform_SDoF_fit(
         - "zeta": Damping ratio.
         - "delta_st": Static deflection.
         - "phi_0": Phase offset in radians.
-        - "EO": Engine order with minimum error.
+        - "EO_best": Engine order with minimum error.
+        - "EO_errors": Dictionary of errors for each engine order.
     """
     df_resonance_window = df_blade.query(f"n >= {n_start} and n <= {n_end}")
     measured_tip_deflection_signals = [
@@ -255,6 +256,7 @@ def perform_SDoF_fit(
     ]
     PROBE_COUNT = len(measured_tip_deflection_signals)
     EO_solutions = []
+    EO_errors = {}  # collect each EO's loss
     for EO in EOs:
         if verbose:
             print("NOW SOLVING FOR EO = ", EO, " of ", EOs)
@@ -302,6 +304,7 @@ def perform_SDoF_fit(
             **differential_evolution_optimiser_kwargs
         )
         EO_solutions.append(multiple_probes_solution)
+        EO_errors[f"EO{EO}"] = multiple_probes_solution.fun
     
     # Select the best EO
     best_EO_arg = np.argmin([solution.fun for solution in EO_solutions])
@@ -312,5 +315,6 @@ def perform_SDoF_fit(
         "zeta" : np.exp(best_solution.x[1]),
         "delta_st" : best_solution.x[2],
         "phi_0" : best_solution.x[3],
-        "EO" : best_EO,
+        "EO_best" : best_EO,
+        "EO_errors" : EO_errors,
     }

--- a/bladesight/btt/infer/sdof.py
+++ b/bladesight/btt/infer/sdof.py
@@ -4,6 +4,8 @@ from typing import List, Dict, Optional
 
 from scipy.optimize import differential_evolution
 
+from tqdm.auto import tqdm
+
 def get_X(
         omega : np.ndarray,
         omega_n : float, 
@@ -258,7 +260,8 @@ def perform_SDoF_fit(
     PROBE_COUNT = len(measured_tip_deflection_signals)
     EO_solutions = []
     EO_errors = {}  # collect each EO's loss
-    for EO in EOs:
+    # for EO in EOs:
+    for EO in tqdm(EOs, desc="Processing EOs"):
         if verbose:
             print("NOW SOLVING FOR EO = ", EO, " of ", EOs)
         

--- a/bladesight/btt/infer/sdof_sweep.py
+++ b/bladesight/btt/infer/sdof_sweep.py
@@ -581,14 +581,6 @@ def perform_SDoF_sweep_fit(
         tip_deflections_set = []
         theta_sensor_set = []
         for i_probe in range(PROBE_COUNT):
-            z_max = df_resonance_window[f"x_p{i_probe+1}"+signal_suffix].abs().max()
-            z_min = -z_max
-            bounds.extend(
-                [
-                    (z_min, z_max),
-                    (z_min, z_max)
-                ]
-            )
             tip_deflections_set.append(
                 df_resonance_window[f"x_p{i_probe+1}"+signal_suffix].values
             )

--- a/bladesight/btt/infer/sdof_sweep.py
+++ b/bladesight/btt/infer/sdof_sweep.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 from scipy.optimize import differential_evolution
 from typing import List, Dict, Optional
+from tqdm.auto import tqdm
 
 
 from .sdof import get_phi
@@ -556,7 +557,8 @@ def perform_SDoF_sweep_fit(
     PROBE_COUNT = len(measured_tip_deflection_signals)
     EO_solutions = []
     EO_errors = {}  # collect each EO's loss
-    for EO in EOs:
+    # for EO in EOs:
+    for EO in tqdm(EOs, desc="Processing EOs"):
         if verbose:
             print("NOW SOLVING FOR EO = ", EO, " of ", EOs)
         

--- a/bladesight/btt/infer/sdof_sweep.py
+++ b/bladesight/btt/infer/sdof_sweep.py
@@ -550,7 +550,8 @@ def perform_SDoF_sweep_fit(
     measured_tip_deflection_signals = [
         col 
         for col in df_resonance_window
-        if col.endswith("_filt")
+        # if col.endswith("_filt")
+        if col.startswith("x_p") and col.endswith(signal_suffix)
     ]
     PROBE_COUNT = len(measured_tip_deflection_signals)
     EO_solutions = []
@@ -562,9 +563,9 @@ def perform_SDoF_sweep_fit(
         if speed_at_resonance_bounds.__contains__(None):
             speed_at_resonance_bounds[0] = df_resonance_window["Omega"].min()
             speed_at_resonance_bounds[1] = df_resonance_window["Omega"].max()
-        if speed_at_resonance_bounds.__contains__(None) == False:
-            speed_at_resonance_bounds[0] = speed_at_resonance_bounds[0]
-            speed_at_resonance_bounds[1] = speed_at_resonance_bounds[1]
+        # if speed_at_resonance_bounds.__contains__(None) == False:
+        #     speed_at_resonance_bounds[0] = speed_at_resonance_bounds[0]
+        #     speed_at_resonance_bounds[1] = speed_at_resonance_bounds[1]
 
         bounds = [
             # (omega_n_bounds[0], omega_n_bounds[1]),

--- a/bladesight/btt/infer/sdof_sweep.py
+++ b/bladesight/btt/infer/sdof_sweep.py
@@ -543,7 +543,8 @@ def perform_SDoF_sweep_fit(
         - "A_max": Resonant maximum amplitude.
         - "C": Constant vibration offset.
         - "speed_at_resonance": Speed at resonance (in radians/second).
-        - "EO": Engine order with minimum error.
+        - "EO_best": Engine order with minimum error.
+        - "EO_errors": Dictionary of errors for each engine order.
     """
     df_resonance_window = df_blade.query(f"n >= {n_start} and n <= {n_end}")
     measured_tip_deflection_signals = [
@@ -553,6 +554,7 @@ def perform_SDoF_sweep_fit(
     ]
     PROBE_COUNT = len(measured_tip_deflection_signals)
     EO_solutions = []
+    EO_errors = {}  # collect each EO's loss
     for EO in EOs:
         if verbose:
             print("NOW SOLVING FOR EO = ", EO, " of ", EOs)
@@ -606,6 +608,7 @@ def perform_SDoF_sweep_fit(
             **differential_evolution_optimiser_kwargs
         )
         EO_solutions.append(multiple_probes_solution)
+        EO_errors[f"EO{EO}"] = multiple_probes_solution.fun
     
     # Select the best EO
     best_EO_arg = np.argmin([solution.fun for solution in EO_solutions])
@@ -622,5 +625,6 @@ def perform_SDoF_sweep_fit(
         "A_max" : best_solution.x[2],
         "C" : best_solution.x[3],
         "speed_at_resonance" : best_solution.x[4],
-        "EO" : best_EO,
+        "EO_best" : best_EO,
+        "EO_errors": EO_errors
     }

--- a/bladesight/btt/infer/sdof_sweep.py
+++ b/bladesight/btt/infer/sdof_sweep.py
@@ -282,6 +282,14 @@ def predict_sdof_samples_sweep(
                                 speed_at_start = Omega_arr[0], speed_at_end = Omega_arr[-1], 
                                 time_at_start = time_arr[0], time_at_end = time_arr[-1]
                                 )
+    
+    if a == 0:
+        raise ValueError("Frequency sweep rate is zero. Please check the input data for valid speed and time values.")
+
+    if a < 0:
+        a = abs(a) # Ensure a is positive for the calculations
+        print("Warning: Frequency sweep rate is negative. Taking the absolute value of the frequency sweep rate to avoid potential issues with calculating the frequency sweep parameter η.")
+
     if verbose == True:
         print(f"Frequency sweep rate, a: {a} (Rad/s)/s = {a*60/(2*np.pi)} (RPM/s)")
 

--- a/bladesight/btt/infer/sdof_sweep.py
+++ b/bladesight/btt/infer/sdof_sweep.py
@@ -235,20 +235,12 @@ def predict_sdof_samples_sweep(
     Parameters
     ----------
     EO : int
-        The engine order used for scaling the excitation frequency.
+        Engine order.
     theta_sensor : float
         The sensor angle in radians (absolute circumferential position of the probe).
     phi_0 : float
         The initial phase of the excitation force in radians.
 
-    # omega_n : float
-    #     The natural frequency of the blade (in rad/s).
-    # zeta : float
-    #     The initial damping ratio (dimensionless). Note that this is overwritten by the 
-    #     revised damping ratio computed from η.
-    # delta_st : float
-    #     The static deflection of the blade (typically in µm).
-    
     Reference [1] parameters:
     Q : float
         Quality factor (dimensionless).
@@ -260,17 +252,20 @@ def predict_sdof_samples_sweep(
         Resonant maximum amplitude of the blade vibration.
     C : float
         Constant vibration offset term used when calculating the predicted tip deflections.
-    
-    Omega_arr : np.ndarray
-        Array of excitation frequencies (in rad/s).
     Omega_n : float
         The rotating speed at resonance (in rad/s).
+    Omega_arr : np.ndarray
+        Array of excitation frequencies (in rad/s).
+    time_arr : np.ndarray
+        Array of corresponding times (s).
+    verbose : bool, optional
+        If True, prints intermediate sweep rate. Defaults to False.
 
 
     Returns
     -------
     np.ndarray
-        The predicted tip deflection values (in the same units as delta_st) for each 
+        The predicted tip deflection values (in the same units as A_max) for each 
         excitation frequency in `arr_omega`.
 
     References
@@ -353,37 +348,49 @@ def SDoF_loss_multiple_probes_sweep(
     verbose: bool = False
 
     ) -> np.ndarray:
-    """ This function fits the SDoF parameters to 
-        multiple probes' data.
+    """ 
+    Loss function for fitting SDoF sweep model to multiple probes.
 
-    Args:
-        model_params (np.ndarray): The SDoF fit method's model parameters. It
-            includes a list of the following parameters:
-            
-            omega_n (float): The natural frequency of the SDoF system.
-            ln_zeta (float): The damping ratio of the SDoF system.
-            delta_st (float): The static deflection of the SDoF system.
-            phi_0 (float): The phase offset of the SDoF system.
-            And then the z_median and z_max for each probe.
-                z_median (float): The amplitude offset at the 
-                    median shaft speed.
-                z_max (float): The maximum amplitude offset.
+    This function fits the SDoF parameters to multiple probes' data.
 
-        tip_deflections_set (List[np.ndarray]): The tip deflection data for each probe.
-        arr_omega (np.ndarray): The angular velocity of the rotor corresponding
-            to the tip deflection data.
-        EO (int): The EO of vibration you want to fit.
-        theta_sensor_set (List[float]): Each sensor's angular position 
-            relative to the start of the revolution.
-        amplitude_scaling_factor (float, optional): A scaling factor to
-            weight the measured tip deflections. Defaults to 1. Use this value
-            to reward solutions that better capture the full amplitude of the
-            tip deflections.
+    Parameters
+    ----------
+    model_params : np.ndarray
+        An array of the following model parameters: [phi_0, Q, A_max, C, Omega_n] where
+        - phi_0 : float
+            Initial phase of the excitation force (rad).
+        - Q : float
+            Quality factor (dimensionless).
+        - A_max : float
+            Resonant maximum amplitude of the blade vibration.
+        - C : float
+            Constant vibration offset term used when calculating the predicted tip deflections.
+        - Omega_n : float
+            The rotating speed at resonance (in rad/s).
+    tip_deflections_set : list of np.ndarray
+        Measured tip deflections for each probe.
+    EO : int
+        Engine order.
+    theta_sensor_set : list of float
+        Sensor angles (rad) for each probe.
+    Omega_arr : np.ndarray
+        Excitation speeds (rad/s).
+    time_arr : np.ndarray
+        Corresponding times (s).
+    amplitude_scaling_factor : float, optional
+        Exponent weight for measured amplitudes. Default is 1.
+    verbose : bool, optional
+        If True, prints progress for each probe.
 
-    Returns:
-        np.ndarray: The sum of squared error between 
-            the tip deflection data of each probe and
-            the predicted tip deflections.
+    Returns
+    -------
+    float
+        Total loss (sum of weighted squared errors).
+
+    References
+    ----------
+    [1] F. Zhi et al., `Error Revising of Blade Tip-Timing Parameter Identification Caused by Frequency Sweep Rate`,
+    Measurement, vol. 201, p. 111681, Sep. 2022, doi: 10.1016/j.measurement.2022.111681.
     """
     # omega_n, ln_zeta, delta_st, phi_0, *correction_factors = model_params
 

--- a/bladesight/btt/infer/sdof_sweep.py
+++ b/bladesight/btt/infer/sdof_sweep.py
@@ -1,0 +1,294 @@
+"""
+This module contains the functions proposed by:
+[1] F. Zhi et al., `Error Revising of Blade Tip-Timing Parameter Identification Caused by Frequency Sweep Rate`,
+Measurement, vol. 201, p. 111681, Sep. 2022, doi: 10.1016/j.measurement.2022.111681.
+
+The notation in this module follows the one used in the reference [1].
+"""
+import numpy as np
+from typing import List, Dict
+
+
+from .sdof import get_phi
+
+# # ------------------ Tradidional Single-parameter Method ------------------ # - i realised after typing this that this is just the existing SDoF method
+# def get_H(
+#         omega : np.ndarray,
+#         omega_n : float, 
+#         zeta: float,
+#         delta_st: float
+#     ) -> np.ndarray:
+#     """
+#     This function returns the vibration amplitude of 
+#     the blade vibration.
+    
+#     x(ω) = 	δ_st / sqrt( (1 - r**2)**2 + (2*ζ*r)**2)
+
+#     where:
+
+#     r = ω/ω_0
+
+#     Parameters
+#     ----------
+#     omega : np.ndarray
+#         The excitation frequencies in rad/s.
+#     omega_n : float
+#         The natural frequency of the blade in rad/s.
+#     zeta : float
+#         The damping ratio of the blade vibration (dimensionless).
+#     delta_st : float
+#         The static deflection of the blade (typically in µm).
+
+#     Returns
+#     -------
+#     np.ndarray
+#         The vibration amplitude of the blade corresponding to each frequency in `omega`
+#         (in the same units as `delta_st`).
+
+#     Notes
+#     -----
+#     In reference [1], the amplitude term A_s is equivalent to the static deflection δ_st used here.
+    
+#     References
+#     ----------
+#     [1] F. Zhi et al., "Error Revising of Blade Tip-Timing Parameter Identification Caused by Frequency Sweep Rate",
+#         Measurement, vol. 201, p. 111681, Sep. 2022, doi: 10.1016/j.measurement.2022.111681.
+#     """
+#     r = omega / omega_n
+#     return (
+#         delta_st 
+#         / np.sqrt(
+#             (1 - r**2)**2 
+#             + (2*zeta*r)**2
+#         )
+#     )
+
+# def predict_sdof_single_probe(
+#     omega_n : float,
+#     zeta : float,
+#     delta_st : float,
+#     EO : int,
+#     theta_sensor : float,
+#     arr_omega : np.ndarray
+# ) -> np.ndarray:
+#     """
+#     Predict blade tip deflections for a single probe using a single-degree-of-freedom (SDOF) model.
+
+#     This function calculates the predicted tip deflection of a blade based on an SDOF model 
+#     using a single probe measurement. The model utilizes the vibration amplitude computed 
+#     by `get_H` and the phase angle computed by `get_phi` for excitation frequencies scaled 
+#     by the engine order (EO). An alternative formulation is then applied involving an 
+#     initial excitation phase (phi_0), assumed to be defined elsewhere in the code.
+
+#     The predicted tip deflection is computed via:
+    
+#         r = arr_omega / omega_n
+#         numerator = (1 - r**2) * cos(EO*theta_sensor + phi_0) + (2*zeta*r) * sin(EO*theta_sensor + phi_0)
+#         denominator = (1 - r**2)**2 + (2*zeta*r)**2
+#         predicted_tip_deflections = delta_st * (numerator / denominator)
+
+#     Here, phi_0 is the initial phase of the excitation force.
+
+#     Parameters
+#     ----------
+#     omega_n : float
+#         Natural frequency of the blade in rad/s.
+#     zeta : float
+#         Damping ratio of the blade vibration (dimensionless).
+#     delta_st : float
+#         Static deflection of the blade (typically in µm).
+#     EO : int
+#         Engine order used to scale the excitation frequencies.
+#     theta_sensor : float
+#         Sensor angle in radians, representing the absolute circumferential position.
+#     arr_omega : np.ndarray
+#         Array of excitation frequencies in rad/s.
+
+#     Returns
+#     -------
+#     np.ndarray
+#         The predicted blade tip deflection values (in the same units as `delta_st`) 
+#         corresponding to each frequency in `arr_omega`.
+
+#     References
+#     ----------
+#     [1] F. Zhi et al., "Error Revising of Blade Tip-Timing Parameter Identification Caused by Frequency Sweep Rate",
+#         Measurement, vol. 201, p. 111681, Sep. 2022, doi: 10.1016/j.measurement.2022.111681.
+
+#     Notes
+#     -----
+#     - The functions `get_H` and `get_phi` are used to compute the amplitude and phase, 
+#     respectively, for the scaled excitation frequencies (arr_omega * EO).
+#     - The variable `phi_0` must be defined in an outer scope; it represents the initial 
+#     phase of the excitation force.
+#     - It is assumed that the variable `omega` in the model formulation is equivalent 
+#     to `arr_omega`.
+#     """
+#     # X = get_H(arr_omega*EO, omega_n, zeta, delta_st)
+#     # phi = get_phi(arr_omega*EO, omega_n, zeta)
+#     # predicted_tip_deflections = X * np.cos(theta_sensor * EO - phi)
+
+#     r = omega / omega_n
+
+#     numerator_term1 = (1 - r**2) * np.cos(EO*theta_sensor + phi_0) # phi_0 is the initial phase of the excitation force
+#     numerator_term2 = (2*zeta*r) * np.sin(EO*theta_sensor + phi_0) # phi_0 is the initial phase of the excitation force
+
+#     numerator = numerator_term1 + numerator_term2
+#     denominator = (1 - r**2)**2 + (2*zeta*r)**2
+
+#     predicted_tip_deflections = delta_st * numerator/denominator
+
+#     return predicted_tip_deflections
+
+
+# ------------------ Frequency Sweep Parameter Method ------------------ #
+def get_eta(EO: int, Q: float, a: float, f_n: float) -> float:
+    """
+    Compute the non-dimensional frequency sweep parameter η.
+
+    Equation (11) in Reference [1]:
+        η = EO * ((Q^2 * a) / (60 * f_n^2))
+
+    Parameters
+    ----------
+    EO : int
+        Engine order.
+    Q : float
+        Quality factor (dimensionless).
+    a : float
+        A scaling parameter (units dependent on application).
+    f_n : float
+        Natural frequency (in Hz or consistent units).
+
+    Returns
+    -------
+    float
+        The computed non-dimensional parameter η.
+
+    References
+    ----------
+    [1] F. Zhi et al., "Error Revising of Blade Tip-Timing Parameter Identification Caused by Frequency Sweep Rate",
+        Measurement, vol. 201, p. 111681, Sep. 2022, doi: 10.1016/j.measurement.2022.111681.
+    """
+    return EO*((Q**2) * a)/(60*f_n**2)
+
+
+def get_A(eta: float) -> float:
+    """
+    Compute the fraction of the peak amplitude factor, A, based on the non-dimensional parameter η.
+
+    Equation (13) in Reference [1]:
+        A = 1 - exp(-2.86 * η^(-0.455))
+
+    Parameters
+    ----------
+    eta : float
+        The non-dimensional parameter η.
+
+    Returns
+    -------
+    float
+        The peak amplitude factor A.
+
+    References
+    ----------
+    [1] F. Zhi et al., "Error Revising of Blade Tip-Timing Parameter Identification Caused by Frequency Sweep Rate",
+        Measurement, vol. 201, p. 111681, Sep. 2022, doi: 10.1016/j.measurement.2022.111681.
+    
+    Notes
+    -----
+    Note reference [1] says that Equation (13) improves on Equation (12), therefore only Equation (13) is implemented here.
+    """
+    return 1 - np.exp(-2.86*eta**(-0.455)) # Equation 13 in Reference [1]
+
+def get_f(eta: float) -> float:
+    """
+    Compute the normalised frequency error, f, based on the non-dimensional parameter η.
+
+    Equation (13) in Reference [1]:
+        f = 0.518 * η^(0.576)
+
+    Parameters
+    ----------
+    eta : float
+        The non-dimensional parameter η.
+
+    Returns
+    -------
+    float
+        The normalised frequency error f.
+
+    References
+    ----------
+    [1] F. Zhi et al., "Error Revising of Blade Tip-Timing Parameter Identification Caused by Frequency Sweep Rate",
+        Measurement, vol. 201, p. 111681, Sep. 2022, doi: 10.1016/j.measurement.2022.111681.
+
+    Notes
+    -----
+    Note reference [1] says that Equation (13) improves on Equation (12), therefore only Equation (13) is implemented here.
+    """    
+    return 0.518*eta**0.576 # Equation 13 in Reference [1]
+
+def get_zeta(eta: float) -> float:
+    """
+    Compute the fraction of damping ratio, ζ, based on the non-dimensional parameter η.
+
+    Equation (14) in Reference [1]:
+        ζ = 1 / A
+
+    where A is computed by `get_A(eta)`.
+
+    Parameters
+    ----------
+    eta : float
+        The non-dimensional parameter η.
+
+    Returns
+    -------
+    float
+        The fraction of damping ratio ζ.
+
+    References
+    ----------
+    [1] F. Zhi et al., "Error Revising of Blade Tip-Timing Parameter Identification Caused by Frequency Sweep Rate",
+        Measurement, vol. 201, p. 111681, Sep. 2022, doi: 10.1016/j.measurement.2022.111681.
+    """
+    return 1/get_A(eta) # Equation 14 in Reference [1]
+
+
+def predict_sdof_samples_sweep(
+    omega_n : float,
+    zeta : float,
+    delta_st : float,
+    EO : int,
+    theta_sensor : float,
+    phi_0 : float,
+    arr_omega : np.ndarray
+) -> np.ndarray:
+    
+    # X = get_X(arr_omega*EO, omega_n, zeta, delta_st)  
+    # phi = get_phi(arr_omega*EO, omega_n, zeta)
+    # predicted_tip_deflections = X * np.cos(theta_sensor * EO - phi + phi_0)
+
+    eta = get_eta(EO = EO, Q = Q, a = a, f_n = f_n)
+    A = get_A(eta=eta)
+    f = get_f(eta=eta)
+    zeta = get_zeta(eta=eta)
+
+    numerator_term1 = A * A_max
+    numerator_term2 = v*np.cos(EO*theta_sensor + phi_0) + np.sin(EO*theta_sensor + phi_0)
+    
+    v = Q/zeta * (
+                (1 - ((speed/(f/Q + 1))*speed_n)**2)/
+                (((speed/(f/Q + 1))*speed_n)**2)
+                )
+
+
+
+    denominator_term1 = speed/((f/Q + 1)*speed_n) # Not sure if its .../((f/Q + 1)*speed_n) or if its .../(f/Q + 1)*speed_n
+    denominator_term2 = (v**2 + 1)
+
+    predicted_tip_deflections = (numerator_term1/denominator_term1) * (numerator_term2/denominator_term2) + C
+    
+    
+    return predicted_tip_deflections

--- a/bladesight/btt/infer/sdof_sweep.py
+++ b/bladesight/btt/infer/sdof_sweep.py
@@ -39,7 +39,7 @@ def get_eta(EO: int, Q: float, a: float,
     # f_n : float
     #     Natural frequency (in Hz or consistent units).
     Omega_n : float
-        The rotating speed at resonance (in rad/s).
+        The rotating speed at resonance (in radians/second).
 
     Returns
     -------
@@ -167,9 +167,9 @@ def get_frequency_sweep_rate_a(speed_at_start: float, speed_at_end: float, time_
     Parameters:
     -----------
     speed_at_start : float
-        The rotating speed at the start of the frequency sweep (in rad/s).
+        The rotating speed at the start of the frequency sweep (in radians/second).
     speed_at_end : float
-        The rotating speed at the end of the frequency sweep (in rad/s).
+        The rotating speed at the end of the frequency sweep (in radians/second).
     time_at_start : float
         The time at the start of the frequency sweep (in seconds).
     time_at_end : float
@@ -178,7 +178,7 @@ def get_frequency_sweep_rate_a(speed_at_start: float, speed_at_end: float, time_
     Returns:
     --------
     float
-        The frequency sweep rate, a (in rad/s^2).
+        The frequency sweep rate, a (in radians/second^2).
 
     References
     ----------
@@ -253,11 +253,11 @@ def predict_sdof_samples_sweep(
     C : float
         Constant vibration offset term used when calculating the predicted tip deflections.
     Omega_n : float
-        The rotating speed at resonance (in rad/s).
+        The rotating speed at resonance (in radians/second).
     Omega_arr : np.ndarray
-        Array of excitation frequencies (in rad/s).
+        Array of excitation frequencies (in radians/second).
     time_arr : np.ndarray
-        Array of corresponding times (s).
+        Array of corresponding times (seconds).
     verbose : bool, optional
         If True, prints intermediate sweep rate. Defaults to False.
 
@@ -374,7 +374,7 @@ def SDoF_loss_multiple_probes_sweep(
         - C : float
             Constant vibration offset term used when calculating the predicted tip deflections.
         - Omega_n : float
-            The rotating speed at resonance (in rad/s).
+            The rotating speed at resonance (in radians/second).
     tip_deflections_set : list of np.ndarray
         Measured tip deflections for each probe.
     EO : int
@@ -382,9 +382,9 @@ def SDoF_loss_multiple_probes_sweep(
     theta_sensor_set : list of float
         Sensor angles (rad) for each probe.
     Omega_arr : np.ndarray
-        Excitation speeds (rad/s).
+        Excitation speeds (radians/second).
     time_arr : np.ndarray
-        Corresponding times (s).
+        Corresponding times (seconds).
     amplitude_scaling_factor : float, optional
         Exponent weight for measured amplitudes. Default is 1.
     verbose : bool, optional

--- a/bladesight/btt/infer/sdof_sweep.py
+++ b/bladesight/btt/infer/sdof_sweep.py
@@ -13,15 +13,18 @@ https://docs.bladesight.com/tutorials/datasets/diamond_et_al_2024_vary_ramp_rate
 import numpy as np
 import pandas as pd
 from scipy.optimize import differential_evolution
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 
 from .sdof import get_phi
 
 # ------------------ Frequency Sweep Parameter Method ------------------ #
-def get_eta(EO: int, Q: float, a: float, 
-            #f_n: float,
-            Omega_n:float) -> float:
+def get_eta(
+            EO: int, 
+            Q: float, a: float, 
+            # f_n: float,
+            speed_at_resonance:float
+            ) -> float:
     """
     Compute the non-dimensional frequency sweep parameter η.
 
@@ -36,10 +39,11 @@ def get_eta(EO: int, Q: float, a: float,
         Quality factor (dimensionless).
     a : float
         Frequency sweep rate (acceleration of rotating speed).
-    # f_n : float
-    #     Natural frequency (in Hz or consistent units).
-    Omega_n : float
-        The rotating speed at resonance (in radians/second).
+    f_n : float
+        Natural frequency (in Hz or consistent units).
+    speed_at_resonance : float
+        The rotating speed at resonance (in radians/second). 
+        This is denoted by Ωₙ in Reference [1] but this notation is not used here to avoid confusion with the omega_n term in sdof.py that denotes the blade vibration natural frequency.
 
     Returns
     -------
@@ -51,8 +55,8 @@ def get_eta(EO: int, Q: float, a: float,
     [1] F. Zhi et al., "Error Revising of Blade Tip-Timing Parameter Identification Caused by Frequency Sweep Rate",
         Measurement, vol. 201, p. 111681, Sep. 2022, doi: 10.1016/j.measurement.2022.111681.
     """
-    # return EO*((Q**2) * a)/(60*(f_n**2))
-    return ((Q**2) * a)/(60*EO*(Omega_n**2)) # Equation 11 in Reference [1], NOT using f_n as its just an extra parameter to pass in unnecessarily
+    # return EO*((Q**2) * a)/(60*(f_n**2)) # Equation 11 in Reference [1], NOT using Omega_n as its confusing with existing bladesight notation in sdof.py
+    return ((Q**2) * a)/(60*EO*(speed_at_resonance**2)) # Equation 11 in Reference [1], NOT using f_n as its just an extra parameter to pass in unnecessarily
 
 def get_A(eta: float) -> float:
     """
@@ -191,7 +195,7 @@ def get_frequency_sweep_rate_a(speed_at_start: float, speed_at_end: float, time_
     """
     return (speed_at_end - speed_at_start) / (time_at_end - time_at_start)
 
-def predict_sdof_samples_sweep(
+def predict_SDoF_sweep_samples(
     EO : int,
     theta_sensor : float,
     phi_0 : float,
@@ -201,7 +205,7 @@ def predict_sdof_samples_sweep(
     # f_n: float,
     A_max: float,
     C: float,
-    Omega_n: float, # Moved Omega_n up here so it can be optimised
+    speed_at_resonance: float, # Moved Omega_n up here so it can be optimised
 
 
     Omega_arr: np.ndarray,
@@ -252,8 +256,9 @@ def predict_sdof_samples_sweep(
         Resonant maximum amplitude of the blade vibration.
     C : float
         Constant vibration offset term used when calculating the predicted tip deflections.
-    Omega_n : float
-        The rotating speed at resonance (in radians/second).
+    speed_at_resonance : float
+        The rotating speed at resonance (in radians/second). 
+        This is denoted by Ωₙ in Reference [1] but this notation is not used here to avoid confusion with the omega_n term in sdof.py that denotes the blade vibration natural frequency.
     Omega_arr : np.ndarray
         Array of excitation frequencies (in radians/second).
     time_arr : np.ndarray
@@ -294,9 +299,11 @@ def predict_sdof_samples_sweep(
         print(f"Frequency sweep rate, a: {a} (Rad/s)/s = {a*60/(2*np.pi)} (RPM/s)")
 
     eta = get_eta(
-                EO = EO, Q = Q, a = a, 
+                EO = EO, 
+                Q = Q, 
+                a = a, 
                 #   f_n = f_n,
-                Omega_n = Omega_n
+                speed_at_resonance = speed_at_resonance
                 )
     
     A = get_A(eta=eta)
@@ -320,11 +327,11 @@ def predict_sdof_samples_sweep(
                 # (Omega_arr/((f/Q + 1)*Omega_n))
                 (
                     1 - (
-                        (Omega_arr/((f/Q + 1)*Omega_n))**2
+                        (Omega_arr/((f/Q + 1)*speed_at_resonance))**2
                         )
                 )
                 /
-                (Omega_arr/((f/Q + 1)*Omega_n))
+                (Omega_arr/((f/Q + 1)*speed_at_resonance))
                 )
 
     numerator_term1 = A * A_max
@@ -333,14 +340,14 @@ def predict_sdof_samples_sweep(
     # denominator_term1 = Omega_arr/(f/Q + 1)*Omega_n #Option 1
     #                                                 # Not sure if its .../((f/Q + 1)*speed_n) or if its .../(f/Q + 1)*speed_n
     denominator_term1 = Omega_arr/( # Option 2
-                                    (f/Q + 1)*Omega_n) # Not sure if its .../((f/Q + 1)*speed_n) or if its .../(f/Q + 1)*speed_n
+                                    (f/Q + 1)*speed_at_resonance) # Not sure if its .../((f/Q + 1)*speed_n) or if its .../(f/Q + 1)*speed_n
     denominator_term2 = (v**2 + 1)
 
     predicted_tip_deflections = (numerator_term1/denominator_term1) * (numerator_term2/denominator_term2) + C
     
     return predicted_tip_deflections
 
-def SDoF_loss_multiple_probes_sweep(
+def SDoF_sweep_loss_multiple_probes(
     model_params : np.ndarray,
     tip_deflections_set : List[np.ndarray],
     EO : int, 
@@ -373,8 +380,9 @@ def SDoF_loss_multiple_probes_sweep(
             Resonant maximum amplitude of the blade vibration.
         - C : float
             Constant vibration offset term used when calculating the predicted tip deflections.
-        - Omega_n : float
-            The rotating speed at resonance (in radians/second).
+        - speed_at_resonance : float
+            The rotating speed at resonance (in radians/second). 
+            This is denoted by Ωₙ in Reference [1] but this notation is not used here to avoid confusion with the omega_n term in sdof.py that denotes the blade vibration natural frequency.
     tip_deflections_set : list of np.ndarray
         Measured tip deflections for each probe.
     EO : int
@@ -409,7 +417,7 @@ def SDoF_loss_multiple_probes_sweep(
     #                             speed_at_start = Omega_arr[0], speed_at_end = Omega_arr[-1],
     #                             time_at_start = time_arr[0], time_at_end = time_arr[-1]
     #                             )
-    phi_0, Q, A_max, C, Omega_n = model_params
+    phi_0, Q, A_max, C, speed_at_resonance = model_params
 
     # zeta = np.exp(ln_zeta)
 
@@ -417,7 +425,7 @@ def SDoF_loss_multiple_probes_sweep(
     error = 0
     for i_probe, arr_tip_deflections in enumerate(tip_deflections_set):    
         theta_sensor = theta_sensor_set[i_probe]
-        predicted_tip_deflections = predict_sdof_samples_sweep(
+        predicted_tip_deflections = predict_SDoF_sweep_samples(
             # omega_n, zeta, delta_st, EO, theta_sensor, phi_0, arr_omega
             EO = EO,
             theta_sensor = theta_sensor,
@@ -430,22 +438,10 @@ def SDoF_loss_multiple_probes_sweep(
             Omega_arr = Omega_arr,
             time_arr = time_arr,
 
-            Omega_n = Omega_n, # now optimising for Omega_n
+            speed_at_resonance = speed_at_resonance, # now optimising for speed_at_resonance so its included in model_params
 
             # verbose = verbose
             )   
-
-        # z_median = correction_factors[i_probe*2]
-        # z_max = correction_factors[i_probe*2+1]
-        # arr_tip_deflection_corrections = predict_sdof_samples_sweep(
-        #     arr_omega, z_median, z_max
-        # )
-        # arr_tip_deflections_corrected = (
-        #     arr_tip_deflections
-        #     + arr_tip_deflection_corrections
-        # )
-
-        # arr_tip_deflection = predicted_tip_deflections
         error += np.sum(
             np.abs(arr_tip_deflections)**amplitude_scaling_factor
             *(
@@ -456,94 +452,175 @@ def SDoF_loss_multiple_probes_sweep(
     return error
 
 
-# def perform_SDoF_fit(
-#     df_blade : pd.DataFrame,
-#     n_start : int,
-#     n_end : int,
-#     EOs : List[int] = np.arange(1, 50),
-#     # delta_st_max : int = 10,
-#     verbose : bool = False,
-#     probe_column_label_suffix : str = "_filt"
-# ) -> Dict[str, float]:
-#     """This function receives a blade tip deflection DataFrame, and returns 
-#     the SDoF fit model parameters after fitting.
+def perform_SDoF_sweep_fit(
+    df_blade : pd.DataFrame,
+    n_start : int,
+    n_end : int,
+    EOs : Optional[List[int]] = np.arange(1, 20),
+    # omega_n_bounds : Optional[List[float]] = [None, None],
+    # zeta_bounds : Optional[List[float]] = [0.0001, 0.3],
+    # delta_st_bounds : Optional[List[float]] = [0, 10],
+    # phi_0_bounds : Optional[List[float]] = [0, 2*np.pi],
 
-#     Args:
-#         df_blade (pd.DataFrame): The blade tip deflection DataFrame.
-#         n_start (int): The starting revolution number of the resonance 
-#             you want to fit.
-#         n_end (int): The ending revolution number of the resonance 
-#             you want to fit.
-#         EOs (List[int], optional): The list of EOs to search for. Defaults 
-#             to np.arange(1, 20).
-#         delta_st_max (int, optional): The maximum static deflection within our optimization 
-#             bounds. Defaults to 10.
-#         verbose (bool, optional): Whether to print the progress. Defaults to False.
+    phi_0_bounds : Optional[List[float]] = [0, 2*np.pi],
+    Q_bounds : Optional[List[float]] = [1, 1000],
+    A_max_bounds : Optional[List[float]] = [-1000, 1000],
+    C_bounds : Optional[List[float]] = [-1000, 1000],
+    speed_at_resonance_bounds : Optional[List[float]] = [None, None],
 
-#     Returns:
-#         Dict[str, float]: The fitted model parameters.
-#     """
-#     df_resonance_window = df_blade.query(f"n >= {n_start} and n <= {n_end}")
-#     measured_tip_deflection_signals = [
-#         col 
-#         for col in df_resonance_window
-#         if col.endswith(probe_column_label_suffix)
-#     ]
-#     PROBE_COUNT = len(measured_tip_deflection_signals)
-#     eo_solutions = []
-#     for EO in EOs:
-#         if verbose:
-#             print("NOW SOLVING FOR EO = ", EO, " of ", EOs)
-#         omega_n_min = df_resonance_window["Omega"].min() * EO
-#         omega_n_max = df_resonance_window["Omega"].max() * EO
-#         ln_zeta_min = np.log(0.0001)
-#         ln_zeta_max = np.log(0.3)
-#         delta_st_min = 0
-#         phi_0_min = 0
-#         phi_0_max = 2*np.pi
-#         bounds = [
-#             (omega_n_min, omega_n_max),
-#             (ln_zeta_min, ln_zeta_max),
-#             (delta_st_min, delta_st_max),
-#             (phi_0_min, phi_0_max),
-#         ]
-#         tip_deflections_set = []
-#         theta_sensor_set = []
-#         for i_probe in range(PROBE_COUNT):
-#             z_max = df_resonance_window[f"x_p{i_probe+1}"+probe_column_label_suffix].abs().max()
-#             z_min = -z_max
-#             bounds.extend(
-#                 [
-#                     (z_min, z_max),
-#                     (z_min, z_max)
-#                 ]
-#             )
-#             tip_deflections_set.append(
-#                 df_resonance_window[f"x_p{i_probe+1}"+probe_column_label_suffix].values
-#             )
-#             theta_sensor_set.append(
-#                 df_resonance_window[f"AoA_p{i_probe+1}"].median()
-#             )
-#         multiple_probes_solution = differential_evolution(
-#             func = SDoF_loss_multiple_probes,
-#             bounds=bounds,
-#             args=(
-#                 tip_deflections_set,
-#                 df_resonance_window['Omega'].values,
-#                 EO,
-#                 theta_sensor_set,
-#                 2
-#             ),
-#             seed=42
-#         )
-#         eo_solutions.append(multiple_probes_solution)
-#     best_EO_arg = np.argmin([solution.fun for solution in eo_solutions])
-#     best_EO = EOs[best_EO_arg]
-#     best_solution = eo_solutions[best_EO_arg]
-#     return {
-#         "omega_n" : best_solution.x[0] / (2*np.pi),
-#         "zeta" : np.exp(best_solution.x[1]),
-#         "delta_st" : best_solution.x[2],
-#         "phi_0" : best_solution.x[3],
-#         "EO" : best_EO,
-#     }
+
+
+    signal_suffix : Optional[str] = "_filt" ,
+    amplitude_scaling_factor : float = 1,
+    differential_evolution_optimiser_kwargs: Optional[dict] = {'seed': 42},
+    verbose : bool = False
+) -> Dict[str, float]:
+    """
+    Fit an SDoF model to blade tip deflection data over a specified revolution range.
+
+    Parameters
+    ----------
+    df_blade : pd.DataFrame
+        The blade tip deflection DataFrame.
+    n_start : int
+        The starting revolution number of the resonance to be used in the fit.
+    n_end : int
+        The ending revolution number of the resonance to be used in the fit.
+    EOs : List[int], optional
+        Range of engine orders to consider, defaults to np.arange(1, 20).
+
+
+
+    # omega_n_bounds : List[float], optional
+    #     [min, max] bounds for resonant speed Ωₙ (radians/second). If None, set per EO as
+    #     (min(df_blade['Omega'])*EO, max(df_blade['Omega'])*EO).
+    # zeta_bounds : list of float, optional
+    #     [min, max] bounds for damping ratio ζ, default to: [0.0001, 0.3].
+    # delta_st_bounds : list of float, optional
+    #     [min, max] bounds for static deflection δₛₜ, , defaults to [0, 10].
+    # phi_0_bounds : list of float, optional
+    #     [min, max] bounds for phase offset φ₀ in radians, defaults to [0, 2π].
+
+    
+    phi_0_bounds : list of float, optional
+        [min, max] bounds for phase offset φ₀ in radians, defaults to [0, 2π].
+    Q_bounds : list of float, optional
+        [min, max] bounds for quality factor Q, defaults to [1, 1000].
+    A_max_bounds : list of float, optional
+        [min, max] bounds for resonant maximum amplitude A_max, defaults to [-1000, 1000].
+    C_bounds : list of float, optional
+        [min, max] bounds for constant vibration offset C, defaults to [-1000, 1000].
+    speed_at_resonance_bounds : list of float, optional
+        [min, max] bounds for speed at resonance (Ωₙ), defaults to [None, None].
+    
+    signal_suffix : str, optional
+        Suffix appended to deflection column names, defaults to "_filt".
+
+        
+    # amplitude_scaling_factor : float, optional
+    #     Scaling factor for amplitude weighting, defaults to 1.
+
+
+    differential_evolution_optimiser_kwargs : dict, optional
+        Additional arguments for the differential evolution optimizer, defaults to {'seed': 42}.
+        If you want to use the default settings, pass an empty dictionary.
+    verbose : bool, optional
+        If True, print progress updates, defaults to False.
+    Returns:
+        Dict[str, float]: The fitted model parameters.
+    Returns
+    -------
+    Dict[str, Union[float, int]]
+        Fitted parameters, including:
+        # - "omega_n": Natural frequency (in Hz).
+        # - "zeta": Damping ratio.
+        # - "delta_st": Static deflection.
+        # - "phi_0": Phase offset in radians.
+        # - "EO": Engine order with minimum error.
+
+        - "phi_0": Initial phase of the excitation force (in radians).
+        - "Q": Quality factor.
+        - "A_max": Resonant maximum amplitude.
+        - "C": Constant vibration offset.
+        - "speed_at_resonance": Speed at resonance (in radians/second).
+        - "EO": Engine order with minimum error.
+    """
+    df_resonance_window = df_blade.query(f"n >= {n_start} and n <= {n_end}")
+    measured_tip_deflection_signals = [
+        col 
+        for col in df_resonance_window
+        if col.endswith("_filt")
+    ]
+    PROBE_COUNT = len(measured_tip_deflection_signals)
+    EO_solutions = []
+    for EO in EOs:
+        if verbose:
+            print("NOW SOLVING FOR EO = ", EO, " of ", EOs)
+        
+        if speed_at_resonance_bounds.__contains__(None):
+            speed_at_resonance_bounds[0] = df_resonance_window["Omega"].min()
+            speed_at_resonance_bounds[1] = df_resonance_window["Omega"].max()
+        if speed_at_resonance_bounds.__contains__(None) == False:
+            speed_at_resonance_bounds[0] = speed_at_resonance_bounds[0]
+            speed_at_resonance_bounds[1] = speed_at_resonance_bounds[1]
+
+        bounds = [
+            # (omega_n_bounds[0], omega_n_bounds[1]),
+            # (zeta_bounds[0], zeta_bounds[1]),
+            # (delta_st_bounds[0], delta_st_bounds[1]),
+            # (phi_0_bounds[0], phi_0_bounds[1]),
+            (phi_0_bounds[0], phi_0_bounds[1]),
+            (Q_bounds[0], Q_bounds[1]),
+            (A_max_bounds[0], A_max_bounds[1]),
+            (C_bounds[0], C_bounds[1]),
+            (speed_at_resonance_bounds[0], speed_at_resonance_bounds[1]),
+        ]
+        tip_deflections_set = []
+        theta_sensor_set = []
+        for i_probe in range(PROBE_COUNT):
+            z_max = df_resonance_window[f"x_p{i_probe+1}"+signal_suffix].abs().max()
+            z_min = -z_max
+            bounds.extend(
+                [
+                    (z_min, z_max),
+                    (z_min, z_max)
+                ]
+            )
+            tip_deflections_set.append(
+                df_resonance_window[f"x_p{i_probe+1}"+signal_suffix].values
+            )
+            theta_sensor_set.append(
+                df_resonance_window[f"AoA_p{i_probe+1}"].median()
+            )
+        multiple_probes_solution = differential_evolution(
+            func = SDoF_sweep_loss_multiple_probes,
+            bounds=bounds,
+            args=(
+                tip_deflections_set,
+                EO,
+                theta_sensor_set,
+                df_resonance_window['Omega'].values,
+                df_resonance_window[f'ToA_p{i_probe+1}'].values,
+                amplitude_scaling_factor,
+            ),
+            **differential_evolution_optimiser_kwargs
+        )
+        EO_solutions.append(multiple_probes_solution)
+    
+    # Select the best EO
+    best_EO_arg = np.argmin([solution.fun for solution in EO_solutions])
+    best_EO = EOs[best_EO_arg]
+    best_solution = EO_solutions[best_EO_arg]
+    return {
+        # "omega_n" : best_solution.x[0] / (2*np.pi),
+        # "zeta" : np.exp(best_solution.x[1]),
+        # "delta_st" : best_solution.x[2],
+        # "phi_0" : best_solution.x[3],
+        # "EO" : best_EO,
+        "phi_0" : best_solution.x[0],
+        "Q" : best_solution.x[1],
+        "A_max" : best_solution.x[2],
+        "C" : best_solution.x[3],
+        "speed_at_resonance" : best_solution.x[4],
+        "EO" : best_EO,
+    }


### PR DESCRIPTION
# Added New Feature: Frequency Estimation Accounting for Sweep Rate and Updated Existing Frequency Estimation Functions

# Description
## New Features
- This addition provides functions that compliment the [varying ramp rate dataset](https://docs.bladesight.com/tutorials/datasets/diamond_et_al_2024_vary_ramp_rates_45/) existing on `bladesight`.
- Added new Python file `sdof_sweep.py` with the functions following from Reference [1]. This file is self-explanitory and works analogously to the existing `bladesight` code with the classical SDoF technique (in the sdof.py Python file). The only difference with the `sdof_sweep.py` is that more parameters need to be optimised. Please see Reference [1] in conjunction with the documentation in `sdof_sweep.py`.
- Only added the essential functions for the Frequency Sweep Parameter method from Reference [1] for the case when the EO vibration is known. If the EO is unknown, the user can loop over multiple EOs to find the EO with the smallest error as done in [Chapter 8](https://docs.bladesight.com/tutorials/intro_to_btt/ch8/) of the `bladesight` tutorial.

## Updates
- Updated `perform_SDoF_fit` and `perform_CFF_fit` to allow the user to have more control over the fit through having more optional input parameters.
- Added TQDM to `perform_SDoF_fit` and `perform_CFF_fit`.

# Problem Worth Mentioning with the New Features from Zhi's Paper
- I do not get the similar values when optimising the frequency sweep parameter as found in Reference [1]. I have looked through this code multiple times and can not find an issue with it. I am getting about 10x to 100x smaller values than expected. But the ramp rates investigated in [varying ramp rate dataset](https://docs.bladesight.com/tutorials/datasets/diamond_et_al_2024_vary_ramp_rates_45/)  are different from those in Reference [1]. Therefore, I ask that this code have a "once over review" before merging to the main branch as I am not sure if this is a flaw in the method or the code implementation. I hypothesize it is the method.
- This means the inferred blade vibration frequency could be calculated incorrectly.
- I also am struggling to test how exactly the blade vibration frequency will be calculated if only the speed at the resonance is being optimised. It seems like to find the true blade vibration frequency (denoted by f in Reference [1]) you need to know f_0 which is the expected vibration frequency. This means a lot of prior knowledge is required which I don't like. I am trying to think of other methods to estimate the blade vibration frequency and would appreciate input here. From the equations in Reference [1] I can not see how to optimise for the blade vibration frequency and have that as a direct output such as for the SDoF method existing on `bladesight`.

# Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

All tests were performed on the [varying ramp rate dataset](https://docs.bladesight.com/tutorials/datasets/diamond_et_al_2024_vary_ramp_rates_45/) existing on `bladesight`. I used this dataset to check that this code is working as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# References
[1] F. Zhi et al., "Error Revising of Blade Tip-Timing Parameter Identification Caused by Frequency Sweep Rate",
Measurement, vol. 201, p. 111681, Sep. 2022, doi: 10.1016/j.measurement.2022.111681.

****